### PR TITLE
Fixed issue with compress_llama.sh and get_model_from_local at utils/model_utils.py 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ The advancements in Large Language Models (LLMs) have been hindered by their sub
 
 ### Installation
 Please keep the version of the transformers package exactly equal to 4.35.2 since the svd-compressed version of LLM has a slight change of model structure (in the `component/.` folder).
+Create and set up a conda environment with python version 3.9 (newer versions break some dependencies)
+```
+conda create -n compress python=3.9
+conda activate compress
+```
+Clone and navigate to the repository
+```
+git clone https://github.com/AIoT-MLSys-Lab/SVD-LLM.git
+```
+Install requirements.txt
 ```
 pip install -r requirements.txt
 ```

--- a/compress_llama.sh
+++ b/compress_llama.sh
@@ -6,6 +6,6 @@ python SVDLLM.py --model jeffwan/llama-7b-hf --step 1 --ratio 0.2 --whitening_ns
 # python SVDLLM.py --model jeffwan/llama-7b-hf --step 1 --ratio 0.2 --whitening_nsamples 256 --dataset wikitext2 --model_seq_len 2048 --save_path ./ --run_low_resource
 
 # evaluate the perplexity of llama_7b_whitening_0.2.pt
-python SVDLLM.py --step 4 --model_path whitening/jeffwan_llama_7b_hf_whitening_0.8.pt
+python SVDLLM.py --step 4 --model_path jeffwan_llama_7b_hf_whitening_only_0.8.pt
 # evaluate the efficiency of llama_7b_whitening_0.2.pt
-python SVDLLM.py --step 5 --model_path whitening/jeffwan_llama_7b_hf_whitening_0.8.pt
+python SVDLLM.py --step 5 --model_path jeffwan_llama_7b_hf_whitening_only_0.8.pt

--- a/utils/model_utils.py
+++ b/utils/model_utils.py
@@ -22,7 +22,7 @@ def get_model_from_huggingface(model_id):
     return model, tokenizer
 
 def get_model_from_local(model_id):
-    pruned_dict = torch.load(model_id, map_location='cpu')
+    pruned_dict = torch.load(model_id, weights_only=False, map_location='cpu')
     tokenizer, model = pruned_dict['tokenizer'], pruned_dict['model']
     return model, tokenizer
 


### PR DESCRIPTION
compress_llama.sh had model load paths that didn't correspond to the model path created by SVDLLM.py in step 1

get_model_from_local didn't work since pytorch >= 2.6 switched the weights_only default from True to False, breaking the model loading